### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+[*.rs]
+indent_style=tab
+indent_size=tab
+tab_width=4
+end_of_line=lf
+charset=utf-8
+trim_trailing_whitespace=true
+max_line_length=100
+insert_final_newline=true
+
+[*.yml]
+indent_style=space
+indent_size=2
+tab_width=8
+end_of_line=lf
+
+[*.sh]
+indent_style=space
+indent_size=2
+tab_width=8
+end_of_line=lf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,51 @@
-[profile.release]
-panic = 'unwind'
-
 [workspace]
 members = [
     'node',
     'pallets/account-linker',
-	'pallets/offchain-worker',
+    'pallets/offchain-worker',
     'runtime',
 ]
+
+[profile.dev]
+opt-level = 0
+debug = true
+debug-assertions = true
+overflow-checks = true
+lto = false
+panic = 'unwind'
+incremental = true
+codegen-units = 256
+rpath = false
+
+[profile.test]
+opt-level = 0
+debug = 2
+debug-assertions = true
+overflow-checks = true
+lto = false
+panic = 'unwind'    # This setting is always ignored.
+incremental = true
+codegen-units = 256
+rpath = false
+
+[profile.bench]
+opt-level = 3
+debug = false
+debug-assertions = false
+overflow-checks = false
+lto = false
+panic = 'unwind'    # This setting is always ignored.
+incremental = false
+codegen-units = 16
+rpath = false
+
+[profile.release]
+opt-level = 3
+debug = false
+debug-assertions = false
+overflow-checks = false
+lto = false
+panic = 'unwind'
+incremental = false
+codegen-units = 16
+rpath = false

--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ Litentry node built with Substrate.
 
 ## License
 Apache-2.0
+
+
+## Set up
+    ```
+    rustup default nightly-2020-10-06
+    ```
+
+    ```
+    cargo build
+    ```
+## Useful links
+    [rustfmt configurations](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md)

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -5,8 +5,8 @@ set -e
 echo "*** Initializing WASM build environment"
 
 if [ -z $CI_PROJECT_NAME ] ; then
-   rustup update nightly
-   rustup update stable
+    rustup update nightly
+    rustup update stable
 fi
 
 rustup target add wasm32-unknown-unknown --toolchain nightly


### PR DESCRIPTION
In this PR, I only didn't change any rust source code, only add configuration for `editorconfig` and the top-level `Cargo.toml`. 

All the format checker should be **done by yourself. No git-hooks to prevent informal code to be pushed into the repository**.  

We follow [Substrate Code Style Guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)