### PR TITLE
add check for too big block expiration

### DIFF
--- a/pallets/account-linker/src/lib.rs
+++ b/pallets/account-linker/src/lib.rs
@@ -17,6 +17,7 @@ mod tests;
 mod btc;
 mod util_eth;
 
+const EXPIRING_BLOCK_NUMBER_MAX: u32 = 10 * 60 * 24 * 30; // 30 days for 6s per block
 pub const MAX_ETH_LINKS: usize = 3;
 pub const MAX_BTC_LINKS: usize = 3;
 
@@ -54,6 +55,7 @@ decl_error! {
 		UnexpectedEthMsgLength,
 		InvalidBTCAddress,
 		InvalidBTCAddressLength,
+		InvalidExpiringBlockNumber,
 	}
 }
 
@@ -83,6 +85,8 @@ decl_module! {
 
 			let current_block_number = <frame_system::Module<T>>::block_number();
 			ensure!(expiring_block_number > current_block_number, Error::<T>::LinkRequestExpired);
+			ensure!((expiring_block_number - current_block_number) < T::BlockNumber::from(EXPIRING_BLOCK_NUMBER_MAX), 
+				Error::<T>::InvalidExpiringBlockNumber);
 
 			// TODO: there is no eth prefix here
 			let mut bytes = b"Link Litentry: ".encode();
@@ -140,6 +144,8 @@ decl_module! {
 
 			let current_block_number = <frame_system::Module<T>>::block_number();
 			ensure!(expiring_block_number > current_block_number, Error::<T>::LinkRequestExpired);
+			ensure!((expiring_block_number - current_block_number) < T::BlockNumber::from(EXPIRING_BLOCK_NUMBER_MAX), 
+				Error::<T>::InvalidExpiringBlockNumber);
 
 			// TODO: we may enlarge this 2
 			if addr_expected.len() < 2 {

--- a/pallets/account-linker/src/tests.rs
+++ b/pallets/account-linker/src/tests.rs
@@ -33,7 +33,7 @@ fn generate_rsv(sig: &[u8; 65]) -> ([u8; 32], [u8; 32], u8) {
 }
 
 #[test]
-fn test_invalid_block_number_btc() {
+fn test_invalid_expiring_block_number_btc() {
 	new_test_ext().execute_with(|| {
 
 		use bitcoin::network::constants::Network;
@@ -238,7 +238,7 @@ fn test_expired_block_number_eth() {
 }
 
 #[test]
-fn test_invalid_block_number_eth() {
+fn test_invalid_expiring_block_number_eth() {
 	new_test_ext().execute_with(|| {
 
 		let account: AccountId32 = AccountId32::from([0u8; 32]);

--- a/pallets/account-linker/src/tests.rs
+++ b/pallets/account-linker/src/tests.rs
@@ -33,6 +33,63 @@ fn generate_rsv(sig: &[u8; 65]) -> ([u8; 32], [u8; 32], u8) {
 }
 
 #[test]
+fn test_invalid_block_number_btc() {
+	new_test_ext().execute_with(|| {
+
+		use bitcoin::network::constants::Network;
+		use bitcoin::util::address::Address;
+		use bitcoin::util::key;
+		use bitcoin::secp256k1::{Secp256k1, Message as BTCMessage};
+		use bitcoin::secp256k1::rand::thread_rng;
+
+		// Generate random key pair
+		let s = Secp256k1::new();
+		let pair = s.generate_keypair(&mut thread_rng());
+		let public_key = key::PublicKey {
+			compressed: true,
+			key: pair.1,
+		};
+
+		// Generate pay-to-pubkey-hash address
+		let address = Address::p2pkh(&public_key, Network::Bitcoin);
+
+		let account: AccountId32 = AccountId32::from([255u8; 32]);
+		let block_number: u32 = crate::EXPIRING_BLOCK_NUMBER_MAX + 1;
+
+		let mut bytes = b"Link Litentry: ".encode();
+		let mut account_vec = account.encode();
+		let mut expiring_block_number_vec = block_number.encode();
+
+		bytes.append(&mut account_vec);
+		bytes.append(&mut expiring_block_number_vec);
+
+		let message = BTCMessage::from_slice(&bytes.keccak256()).unwrap();
+
+		let (v, rs) = s.sign_recoverable(&message, &pair.0).serialize_compact();
+
+		let mut r = [0u8; 32];
+		let mut s = [0u8; 32];
+
+		r[..32].copy_from_slice(&rs[..32]);
+		s[..32].copy_from_slice(&rs[32..64]);
+
+		assert_noop!(
+			AccountLinker::link_btc(
+				Origin::signed(account.clone()),
+				account.clone(),
+				0,
+				address.clone().to_string().as_bytes().to_vec(),
+				block_number,
+				r,
+				s,
+				v.to_i32() as u8),
+			AccountLinkerError::InvalidExpiringBlockNumber
+		);
+
+	});
+}
+
+#[test]
 fn test_btc_link_p2pkh() {
 	new_test_ext().execute_with(|| {
 
@@ -90,6 +147,7 @@ fn test_btc_link_p2pkh() {
 
 	});
 }
+
 #[test]
 fn test_btc_link_p2wpkh() {
 	new_test_ext().execute_with(|| {
@@ -151,7 +209,7 @@ fn test_btc_link_p2wpkh() {
 }
 
 #[test]
-fn test_invalid_block_number() {
+fn test_expired_block_number_eth() {
 	new_test_ext().execute_with(|| {
 
 		let account: AccountId32 = AccountId32::from([0u8; 32]);
@@ -175,6 +233,35 @@ fn test_invalid_block_number() {
 				s,
 				v),
 			AccountLinkerError::LinkRequestExpired
+		);
+	});
+}
+
+#[test]
+fn test_invalid_block_number_eth() {
+	new_test_ext().execute_with(|| {
+
+		let account: AccountId32 = AccountId32::from([0u8; 32]);
+		let block_number: u32 = crate::EXPIRING_BLOCK_NUMBER_MAX + 1;
+
+		let mut gen = Random{};
+		let key_pair = gen.generate().unwrap();
+
+		let msg = generate_msg(&account, block_number);
+		let sig = generate_sig(&key_pair, &msg);
+		let (r, s, v) = generate_rsv(&sig);
+
+		assert_noop!(
+			AccountLinker::link_eth(
+				Origin::signed(account.clone()),
+				account.clone(),
+				0,
+				key_pair.address().to_fixed_bytes(),
+				block_number,
+				r,
+				s,
+				v),
+			AccountLinkerError::InvalidExpiringBlockNumber
 		);
 	});
 }


### PR DESCRIPTION
As SlowMist's audit pointed out, it is better to have a rough runtime check to avoid a too big block expiration